### PR TITLE
Calls to NVIC APIs changed into vIRQ ones

### DIFF
--- a/module.json
+++ b/module.json
@@ -15,6 +15,7 @@
     "mbed-hal-st-stm32f4"
   ],
   "dependencies": {
+    "uvisor-lib": "~0.7.0",
     "mbed-hal-st-stm32cubef4": "~0.0.0",
     "mbed-hal": "*"
   },

--- a/source/gpio_irq_api.c
+++ b/source/gpio_irq_api.c
@@ -28,6 +28,7 @@
  *******************************************************************************
  */
 #include <stddef.h>
+#include "uvisor-lib/uvisor-lib.h"
 #include "cmsis.h"
 #include "gpio_irq_api.h"
 #include "pinmap.h"
@@ -235,8 +236,8 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     pin_function(pin, STM_PIN_DATA(STM_MODE_IT_FALLING, GPIO_NOPULL, 0));
 
     // Enable EXTI interrupt
-    NVIC_SetVector(irq_n, vector);
-    NVIC_EnableIRQ(irq_n);
+    vIRQ_SetVector(irq_n, vector);
+    vIRQ_EnableIRQ(irq_n);
 
     // Save informations for future use
     obj->irq_n = irq_n;
@@ -322,11 +323,11 @@ void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable)
 
 void gpio_irq_enable(gpio_irq_t *obj)
 {
-    NVIC_EnableIRQ(obj->irq_n);
+    vIRQ_EnableIRQ(obj->irq_n);
 }
 
 void gpio_irq_disable(gpio_irq_t *obj)
 {
-    NVIC_DisableIRQ(obj->irq_n);
+    vIRQ_DisableIRQ(obj->irq_n);
     obj->event = EDGE_NONE;
 }

--- a/source/serial_api.c
+++ b/source/serial_api.c
@@ -27,6 +27,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************
  */
+#include "uvisor-lib/uvisor-lib.h"
 #include "mbed_assert.h"
 #include "serial_api.h"
 
@@ -388,8 +389,8 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
             __HAL_UART_ENABLE_IT(&UartHandle, UART_IT_TC);
         }
 
-        NVIC_SetVector(irq_n, vector);
-        NVIC_EnableIRQ(irq_n);
+        vIRQ_SetVector(irq_n, vector);
+        vIRQ_EnableIRQ(irq_n);
 
     } else { // disable
 
@@ -405,7 +406,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
             if ((UartHandle.Instance->CR1 & USART_CR1_RXNEIE) == 0) all_disabled = 1;
         }
 
-        if (all_disabled) NVIC_DisableIRQ(irq_n);
+        if (all_disabled) vIRQ_DisableIRQ(irq_n);
 
     }
 }


### PR DESCRIPTION
Calls to NVIC APIs are here replaced with vIRQ ones.

vIRQ provides virtualisation for interrupts and is backward compatible with NVIC. It needs `uvisor-lib` as a dependency.

For more information:
- [vIRQ APIs docs in `uvisor-lib`](https://github.com/ARMmbed/uvisor-lib/blob/master/DOCUMENTATION.md#interrupt-management)
- [Porting to vIRQ in `mbed-hal-ksdk-mcu`](https://github.com/ARMmbed/mbed-hal-ksdk-mcu-private/pull/17)
