### PR TITLE
lp ticker impl

### DIFF
--- a/source/lp_ticker.c
+++ b/source/lp_ticker.c
@@ -19,6 +19,8 @@
 #if DEVICE_LOWPOWERTIMER
 
 #include "lp_ticker_api.h"
+#include "sleep_api.h"
+#include "uvisor-lib/uvisor-lib.h"
 
 static TIM_HandleTypeDef TimMasterHandle;
 static uint8_t lp_ticker_inited = 0;
@@ -77,6 +79,14 @@ void lp_ticker_set_interrupt(uint32_t now, uint32_t time) {
     __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_1, time);
     // Enable IT
     __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC1);
+}
+
+void lp_ticker_sleep_until(uint32_t now, uint32_t time)
+{
+    lp_ticker_set_interrupt(now, time);
+    sleep_t sleep_obj;
+    mbed_enter_sleep(&sleep_obj);
+    mbed_exit_sleep(&sleep_obj);
 }
 
 #endif

--- a/source/sleep.c
+++ b/source/sleep.c
@@ -33,29 +33,23 @@
 
 #include "cmsis.h"
 
-static TIM_HandleTypeDef TimMasterHandle;
-
-void sleep(void)
+void mbed_enter_sleep(sleep_t *obj)
 {
-    TimMasterHandle.Instance = TIM5;
+    // This currently goes to Sleep Mode, because lp ticker implementation is not
+    // available in the STOP mode
+    obj->TimMasterHandle.Instance = TIM5;
 
     // Disable HAL tick interrupt
-    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+    __HAL_TIM_DISABLE_IT(&obj->TimMasterHandle, TIM_IT_CC2);
 
     // Request to enter SLEEP mode
     HAL_PWR_EnterSLEEPMode(PWR_MAINREGULATOR_ON, PWR_SLEEPENTRY_WFI);
-
-    // Enable HAL tick interrupt
-    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
 }
 
-void deepsleep(void)
+void mbed_exit_sleep(sleep_t *obj)
 {
-    // Request to enter STOP mode with regulator in low power mode
-    HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);
-
-    // After wake-up from STOP reconfigure the PLL
-    SetSysClock();
+    // Enable HAL tick interrupt
+    __HAL_TIM_ENABLE_IT(&obj->TimMasterHandle, TIM_IT_CC2);
 }
 
 #endif


### PR DESCRIPTION
This provides lp ticker implementation for F4 devices. It is implemented on top of TIM2 general timer, RTC will come as replacement of this timer as we agreed. 

Note - I was not able to find a timer which is not used by PWM, therefore we might want to disable TIM2 channels in pwm until RTC implementation for lp timer comes in.

I tested this with minar platform mbed.

@bremoran @bogdanm 
