### PR TITLE
Combine STM32F439 and STM32F429 HALs

### DIFF
--- a/module.json
+++ b/module.json
@@ -24,14 +24,11 @@
     "mbed-hal": "*"
   },
   "targetDependencies": {
-    "stm32f401re": {
-      "mbed-hal-st-stm32f401re": "~0.0.0"
-    },
     "stm32f429zi": {
       "mbed-hal-st-stm32f429zi": "~0.2.0"
     },
     "stm32f439zi": {
-      "mbed-hal-st-stm32f439zi": "~0.0.0"
+      "mbed-hal-st-stm32f429zi": "~0.2.0"
     }
   }
 }


### PR DESCRIPTION
The STM32F429 and the STM32F439 are nearly identical, so combine them together.

This will eventually require further changes provided by yotta config