### PR TITLE
Bumped dependency version on uvisor-lib

### DIFF
--- a/module.json
+++ b/module.json
@@ -19,7 +19,7 @@
     "mbed-hal-st-stm32f4"
   ],
   "dependencies": {
-    "uvisor-lib": "~0.7.0",
+    "uvisor-lib": "~0.8.0",
     "mbed-hal-st-stm32cubef4": "~0.1.0",
     "mbed-hal": "*"
   },


### PR DESCRIPTION
Requires https://github.com/ARMmbed/target-st-stm32f429i-disco/pull/9 to bu merged, bumped and published
@bremoran @autopulated 