### PR TITLE
Implement asynchronous SPI interface

### DIFF
--- a/source/spi_api.c
+++ b/source/spi_api.c
@@ -27,39 +27,44 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************
  */
+#include "uvisor-lib/uvisor-lib.h"
 #include "mbed_assert.h"
 #include "spi_api.h"
 
 #if DEVICE_SPI
 
 #include <math.h>
+#include <stdbool.h>
 #include "cmsis.h"
 #include "pinmap.h"
 #include "PeripheralPins.h"
+#include "target_config.h"
 
-static SPI_HandleTypeDef SpiHandle;
+static SPI_HandleTypeDef SpiHandle[MODULE_SIZE_SPI];
+static const IRQn_Type SpiIRQs[MODULE_SIZE_SPI] = {
+    SPI1_IRQn,
+    SPI2_IRQn,
+    SPI3_IRQn,
+#if MODULE_SIZE_SPI > 3
+    SPI4_IRQn,
+#endif
+#if MODULE_SIZE_SPI > 4
+    SPI5_IRQn,
+#endif
+#if MODULE_SIZE_SPI > 5
+    SPI6_IRQn
+#endif
+};
 
 static void init_spi(spi_t *obj)
 {
-    SpiHandle.Instance = (SPI_TypeDef *)(obj->spi);
+    SPI_HandleTypeDef *handle = &SpiHandle[obj->spi.module];
 
-    __HAL_SPI_DISABLE(&SpiHandle);
+    __HAL_SPI_DISABLE(handle);
 
-    SpiHandle.Init.Mode              = SPI_MODE_MASTER;
-    SpiHandle.Init.BaudRatePrescaler = obj->br_presc;
-    SpiHandle.Init.Direction         = SPI_DIRECTION_2LINES;
-    SpiHandle.Init.CLKPhase          = obj->cpha;
-    SpiHandle.Init.CLKPolarity       = obj->cpol;
-    SpiHandle.Init.CRCCalculation    = SPI_CRCCALCULATION_DISABLED;
-    SpiHandle.Init.CRCPolynomial     = 7;
-    SpiHandle.Init.DataSize          = obj->bits;
-    SpiHandle.Init.FirstBit          = obj->order;
-    SpiHandle.Init.NSS               = SPI_NSS_SOFT;
-    SpiHandle.Init.TIMode            = SPI_TIMODE_DISABLED;
+    HAL_SPI_Init(handle);
 
-    HAL_SPI_Init(&SpiHandle);
-
-    __HAL_SPI_ENABLE(&SpiHandle);
+    __HAL_SPI_ENABLE(handle);
 }
 
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk)
@@ -71,48 +76,73 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk)
 
     SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
 
-    obj->spi = (SPIName)pinmap_merge(spi_data, spi_sclk);
-    MBED_ASSERT(obj->spi != (SPIName)NC);
+    SPIName instance = (SPIName)pinmap_merge(spi_data, spi_sclk);
+    MBED_ASSERT(instance != (SPIName)NC);
 
-    // Enable SPI clock
-    if (obj->spi == SPI_1) {
-        __SPI1_CLK_ENABLE();
-    }
+    // Enable SPI clock and set the right module number
+    switch(instance)
+    {
+        case SPI_1:
+            __SPI1_CLK_ENABLE();
+            obj->spi.module = 0;
+            break;
 
-    if (obj->spi == SPI_2) {
-        __SPI2_CLK_ENABLE();
-    }
+        case SPI_2:
+            __SPI2_CLK_ENABLE();
+            obj->spi.module = 1;
+            break;
 
-    if (obj->spi == SPI_3) {
-        __SPI3_CLK_ENABLE();
-    }
+        case SPI_3:
+            __SPI3_CLK_ENABLE();
+            obj->spi.module = 2;
+            break;
 
-#if defined SPI4_BASE
-    if (obj->spi == SPI_4) {
-        __SPI4_CLK_ENABLE();
-    }
+#if MODULE_SIZE_SPI > 3
+        case SPI_4:
+            __SPI4_CLK_ENABLE();
+            obj->spi.module = 3;
+            break;
 #endif
-
-#if defined SPI5_BASE
-    if (obj->spi == SPI_5) {
-        __SPI5_CLK_ENABLE();
-    }
+#if MODULE_SIZE_SPI > 4
+        case SPI_5:
+            __SPI5_CLK_ENABLE();
+            obj->spi.module = 4;
+            break;
 #endif
+#if MODULE_SIZE_SPI > 5
+        case SPI_6:
+            __SPI6_CLK_ENABLE();
+            obj->spi.module = 5;
+            break;
+#endif
+        default:
+            break;
+    }
 
     // Configure the SPI pins
     pinmap_pinout(mosi, PinMap_SPI_MOSI);
     pinmap_pinout(miso, PinMap_SPI_MISO);
     pinmap_pinout(sclk, PinMap_SPI_SCLK);
 
-    // Save new values
-    obj->bits = SPI_DATASIZE_8BIT;
-    obj->cpol = SPI_POLARITY_LOW;
-    obj->cpha = SPI_PHASE_1EDGE;
-    obj->br_presc = SPI_BAUDRATEPRESCALER_256;
+    obj->spi.pin_miso = miso;
+    obj->spi.pin_mosi = mosi;
+    obj->spi.pin_sclk = sclk;
 
-    obj->pin_miso = miso;
-    obj->pin_mosi = mosi;
-    obj->pin_sclk = sclk;
+    // initialize the handle for this master!
+    SPI_HandleTypeDef *handle = &SpiHandle[obj->spi.module];
+
+    handle->Instance               = (SPI_TypeDef *)(instance);
+    handle->Init.Mode              = SPI_MODE_MASTER;
+    handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_256;
+    handle->Init.Direction         = SPI_DIRECTION_2LINES;
+    handle->Init.CLKPhase          = SPI_PHASE_1EDGE;
+    handle->Init.CLKPolarity       = SPI_POLARITY_LOW;
+    handle->Init.CRCCalculation    = SPI_CRCCALCULATION_DISABLED;
+    handle->Init.CRCPolynomial     = 7;
+    handle->Init.DataSize          = SPI_DATASIZE_8BIT;
+    handle->Init.FirstBit          = SPI_FIRSTBIT_MSB;
+    handle->Init.NSS               = SPI_NSS_SOFT;
+    handle->Init.TIMode            = SPI_TIMODE_DISABLED;
 
     init_spi(obj);
 }
@@ -120,78 +150,91 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk)
 void spi_free(spi_t *obj)
 {
     // Reset SPI and disable clock
-    if (obj->spi == SPI_1) {
-        __SPI1_FORCE_RESET();
-        __SPI1_RELEASE_RESET();
-        __SPI1_CLK_DISABLE();
-    }
+    switch(obj->spi.module)
+    {
+        case 0:
+            __SPI1_FORCE_RESET();
+            __SPI1_RELEASE_RESET();
+            __SPI1_CLK_DISABLE();
+            break;
 
-    if (obj->spi == SPI_2) {
-        __SPI2_FORCE_RESET();
-        __SPI2_RELEASE_RESET();
-        __SPI2_CLK_DISABLE();
-    }
+        case 1:
+            __SPI2_FORCE_RESET();
+            __SPI2_RELEASE_RESET();
+            __SPI2_CLK_DISABLE();
+            break;
 
-    if (obj->spi == SPI_3) {
-        __SPI3_FORCE_RESET();
-        __SPI3_RELEASE_RESET();
-        __SPI3_CLK_DISABLE();
-    }
+        case 2:
+            __SPI3_FORCE_RESET();
+            __SPI3_RELEASE_RESET();
+            __SPI3_CLK_DISABLE();
+            break;
 
-#if defined SPI4_BASE
-    if (obj->spi == SPI_4) {
-        __SPI4_FORCE_RESET();
-        __SPI4_RELEASE_RESET();
-        __SPI4_CLK_DISABLE();
-    }
+#if MODULE_SIZE_SPI > 3
+        case 3:
+            __SPI4_FORCE_RESET();
+            __SPI4_RELEASE_RESET();
+            __SPI4_CLK_DISABLE();
+            break;
 #endif
-
-#if defined SPI5_BASE
-    if (obj->spi == SPI_5) {
-        __SPI5_FORCE_RESET();
-        __SPI5_RELEASE_RESET();
-        __SPI5_CLK_DISABLE();
-    }
+#if MODULE_SIZE_SPI > 4
+        case 4:
+            __SPI5_FORCE_RESET();
+            __SPI5_RELEASE_RESET();
+            __SPI5_CLK_DISABLE();
+            break;
 #endif
+#if MODULE_SIZE_SPI > 5
+        case 5:
+            __SPI6_FORCE_RESET();
+            __SPI6_RELEASE_RESET();
+            __SPI6_CLK_DISABLE();
+            break;
+#endif
+        default:
+            break;
+    }
 
     // Configure GPIOs
-    pin_function(obj->pin_miso, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-    pin_function(obj->pin_mosi, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-    pin_function(obj->pin_sclk, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+    pin_function(obj->spi.pin_miso, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+    pin_function(obj->spi.pin_mosi, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+    pin_function(obj->spi.pin_sclk, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
 }
 
 void spi_format(spi_t *obj, int bits, int mode, spi_bitorder_t order)
 {
+    SPI_HandleTypeDef *handle = &SpiHandle[obj->spi.module];
+
     // Save new values
     if (bits == 16) {
-        obj->bits = SPI_DATASIZE_16BIT;
+        handle->Init.DataSize = SPI_DATASIZE_16BIT;
     } else {
-        obj->bits = SPI_DATASIZE_8BIT;
+        handle->Init.DataSize = SPI_DATASIZE_8BIT;
     }
 
     switch (mode) {
         case 0:
-            obj->cpol = SPI_POLARITY_LOW;
-            obj->cpha = SPI_PHASE_1EDGE;
+            handle->Init.CLKPolarity = SPI_POLARITY_LOW;
+            handle->Init.CLKPhase = SPI_PHASE_1EDGE;
             break;
         case 1:
-            obj->cpol = SPI_POLARITY_LOW;
-            obj->cpha = SPI_PHASE_2EDGE;
+            handle->Init.CLKPolarity = SPI_POLARITY_LOW;
+            handle->Init.CLKPhase = SPI_PHASE_2EDGE;
             break;
         case 2:
-            obj->cpol = SPI_POLARITY_HIGH;
-            obj->cpha = SPI_PHASE_1EDGE;
+            handle->Init.CLKPolarity = SPI_POLARITY_HIGH;
+            handle->Init.CLKPhase = SPI_PHASE_1EDGE;
             break;
         default:
-            obj->cpol = SPI_POLARITY_HIGH;
-            obj->cpha = SPI_PHASE_2EDGE;
+            handle->Init.CLKPolarity = SPI_POLARITY_HIGH;
+            handle->Init.CLKPhase = SPI_PHASE_2EDGE;
             break;
     }
 
     if (order == SPI_MSB) {
-        obj->order = SPI_FIRSTBIT_MSB;
+        handle->Init.FirstBit = SPI_FIRSTBIT_MSB;
     } else {
-        obj->order = SPI_FIRSTBIT_LSB;
+        handle->Init.FirstBit = SPI_FIRSTBIT_LSB;
     }
 
     init_spi(obj);
@@ -199,139 +242,146 @@ void spi_format(spi_t *obj, int bits, int mode, spi_bitorder_t order)
 
 void spi_frequency(spi_t *obj, int hz)
 {
+    SPI_HandleTypeDef *handle = &SpiHandle[obj->spi.module];
+
 #if defined(TARGET_STM32F401RE) || defined(TARGET_STM32F401VC) || defined(TARGET_STM32F407VG)
     // Note: The frequencies are obtained with SPI1 clock = 84 MHz (APB2 clock)
     if (hz < 600000) {
-        obj->br_presc = SPI_BAUDRATEPRESCALER_256; // 330 kHz
+        handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_256; // 330 kHz
     } else if ((hz >= 600000) && (hz < 1000000)) {
-        obj->br_presc = SPI_BAUDRATEPRESCALER_128; // 656 kHz
+        handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_128; // 656 kHz
     } else if ((hz >= 1000000) && (hz < 2000000)) {
-        obj->br_presc = SPI_BAUDRATEPRESCALER_64; // 1.3 MHz
+        handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_64; // 1.3 MHz
     } else if ((hz >= 2000000) && (hz < 5000000)) {
-        obj->br_presc = SPI_BAUDRATEPRESCALER_32; // 2.6 MHz
+        handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_32; // 2.6 MHz
     } else if ((hz >= 5000000) && (hz < 10000000)) {
-        obj->br_presc = SPI_BAUDRATEPRESCALER_16; // 5.25 MHz
+        handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_16; // 5.25 MHz
     } else if ((hz >= 10000000) && (hz < 21000000)) {
-        obj->br_presc = SPI_BAUDRATEPRESCALER_8; // 10.5 MHz
+        handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_8; // 10.5 MHz
     } else if ((hz >= 21000000) && (hz < 42000000)) {
-        obj->br_presc = SPI_BAUDRATEPRESCALER_4; // 21 MHz
+        handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_4; // 21 MHz
     } else { // >= 42000000
-        obj->br_presc = SPI_BAUDRATEPRESCALER_2; // 42 MHz
+        handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_2; // 42 MHz
     }
 #elif defined(TARGET_STM32F405RG)
     // Note: The frequencies are obtained with SPI1 clock = 48 MHz (APB2 clock)
-    if (obj->spi == SPI_1) {
+    if (obj->spi.module == 0) {
         if (hz < 375000) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_256; // 187.5 kHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_256; // 187.5 kHz
         } else if ((hz >= 375000) && (hz < 750000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_128; // 375 kHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_128; // 375 kHz
         } else if ((hz >= 750000) && (hz < 1500000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_64; // 0.75 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_64; // 0.75 MHz
         } else if ((hz >= 1500000) && (hz < 3000000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_32; // 1.5 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_32; // 1.5 MHz
         } else if ((hz >= 3000000) && (hz < 6000000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_16; // 3 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_16; // 3 MHz
         } else if ((hz >= 6000000) && (hz < 12000000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_8; // 6 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_8; // 6 MHz
         } else if ((hz >= 12000000) && (hz < 24000000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_4; // 12 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_4; // 12 MHz
         } else { // >= 24000000
-            obj->br_presc = SPI_BAUDRATEPRESCALER_2; // 24 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_2; // 24 MHz
         }
     // Note: The frequencies are obtained with SPI2/3 clock = 48 MHz (APB1 clock)
-    } else if ((obj->spi == SPI_2) || (obj->spi == SPI_3)) {
+    } else if ((obj->spi.module == 1) || (obj->spi.module == 2)) {
         if (hz < 375000) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_256; // 187.5 kHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_256; // 187.5 kHz
         } else if ((hz >= 375000) && (hz < 750000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_128; // 375 kHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_128; // 375 kHz
         } else if ((hz >= 750000) && (hz < 1500000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_64; // 0.75 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_64; // 0.75 MHz
         } else if ((hz >= 1500000) && (hz < 3000000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_32; // 1.5 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_32; // 1.5 MHz
         } else if ((hz >= 3000000) && (hz < 6000000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_16; // 3 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_16; // 3 MHz
         } else if ((hz >= 6000000) && (hz < 12000000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_8; // 6 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_8; // 6 MHz
         } else if ((hz >= 12000000) && (hz < 24000000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_4; // 12 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_4; // 12 MHz
         } else { // >= 24000000
-            obj->br_presc = SPI_BAUDRATEPRESCALER_2; // 24 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_2; // 24 MHz
         }
     }
-#elif defined(TARGET_STM32F411RE) || defined(TARGET_STM32F429ZI)
+#elif defined(TARGET_STM32F411RE) || defined(TARGET_STM32F429ZI) || defined(TARGET_STM32F439ZI)
     // Values depend of PCLK2: 100 MHz
-    if ((obj->spi == SPI_1) || (obj->spi == SPI_4) || (obj->spi == SPI_5)) {
+    if ((obj->spi.module == 0) || (obj->spi.module == 3) || (obj->spi.module == 4)) {
         if (hz < 700000) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_256; // 391 kHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_256; // 391 kHz
         } else if ((hz >= 700000) && (hz < 1000000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_128; // 781 kHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_128; // 781 kHz
         } else if ((hz >= 1000000) && (hz < 3000000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_64;  // 1.56 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_64;  // 1.56 MHz
         } else if ((hz >= 3000000) && (hz < 6000000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_32;  // 3.13 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_32;  // 3.13 MHz
         } else if ((hz >= 6000000) && (hz < 12000000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_16;  // 6.25 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_16;  // 6.25 MHz
         } else if ((hz >= 12000000) && (hz < 25000000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_8;   // 12.5 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_8;   // 12.5 MHz
         } else if ((hz >= 25000000) && (hz < 50000000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_4;   // 25 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_4;   // 25 MHz
         } else { // >= 50000000
-            obj->br_presc = SPI_BAUDRATEPRESCALER_2;   // 50 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_2;   // 50 MHz
         }
     }
 
     // Values depend of PCLK1: 50 MHz
-    if ((obj->spi == SPI_2) || (obj->spi == SPI_3)) {
+    if ((obj->spi.module == 1) || (obj->spi.module == 2)) {
         if (hz < 400000) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_256; // 195 kHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_256; // 195 kHz
         } else if ((hz >= 400000) && (hz < 700000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_128; // 391 kHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_128; // 391 kHz
         } else if ((hz >= 700000) && (hz < 1000000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_64;  // 781 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_64;  // 781 MHz
         } else if ((hz >= 1000000) && (hz < 3000000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_32;  // 1.56 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_32;  // 1.56 MHz
         } else if ((hz >= 3000000) && (hz < 6000000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_16;  // 3.13 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_16;  // 3.13 MHz
         } else if ((hz >= 6000000) && (hz < 12000000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_8;   // 6.25 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_8;   // 6.25 MHz
         } else if ((hz >= 12000000) && (hz < 25000000)) {
-            obj->br_presc = SPI_BAUDRATEPRESCALER_4;   // 12.5 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_4;   // 12.5 MHz
         } else { // >= 25000000
-            obj->br_presc = SPI_BAUDRATEPRESCALER_2;   // 25 MHz
+            handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_2;   // 25 MHz
         }
     }
 #endif
     init_spi(obj);
 }
 
+uint8_t spi_get_module(spi_t *obj)
+{
+    return obj->spi.module;
+}
+
 static inline int ssp_readable(spi_t *obj)
 {
     int status;
-    SpiHandle.Instance = (SPI_TypeDef *)(obj->spi);
+    SPI_HandleTypeDef *handle = &SpiHandle[obj->spi.module];
     // Check if data is received
-    status = ((__HAL_SPI_GET_FLAG(&SpiHandle, SPI_FLAG_RXNE) != RESET) ? 1 : 0);
+    status = ((__HAL_SPI_GET_FLAG(handle, SPI_FLAG_RXNE) != RESET) ? 1 : 0);
     return status;
 }
 
 static inline int ssp_writeable(spi_t *obj)
 {
     int status;
-    SpiHandle.Instance = (SPI_TypeDef *)(obj->spi);
+    SPI_HandleTypeDef *handle = &SpiHandle[obj->spi.module];
     // Check if data is transmitted
-    status = ((__HAL_SPI_GET_FLAG(&SpiHandle, SPI_FLAG_TXE) != RESET) ? 1 : 0);
+    status = ((__HAL_SPI_GET_FLAG(handle, SPI_FLAG_TXE) != RESET) ? 1 : 0);
     return status;
 }
 
 static inline void ssp_write(spi_t *obj, int value)
 {
-    SPI_TypeDef *spi = (SPI_TypeDef *)(obj->spi);
+    SPI_TypeDef *spi = (SPI_TypeDef *)SpiHandle[obj->spi.module].Instance;
     while (!ssp_writeable(obj));
     spi->DR = (uint16_t)value;
 }
 
 static inline int ssp_read(spi_t *obj)
 {
-    SPI_TypeDef *spi = (SPI_TypeDef *)(obj->spi);
+    SPI_TypeDef *spi = (SPI_TypeDef *)SpiHandle[obj->spi.module].Instance;
     while (!ssp_readable(obj));
     return (int)spi->DR;
 }
@@ -339,8 +389,8 @@ static inline int ssp_read(spi_t *obj)
 static inline int ssp_busy(spi_t *obj)
 {
     int status;
-    SpiHandle.Instance = (SPI_TypeDef *)(obj->spi);
-    status = ((__HAL_SPI_GET_FLAG(&SpiHandle, SPI_FLAG_BSY) != RESET) ? 1 : 0);
+    SPI_HandleTypeDef *handle = &SpiHandle[obj->spi.module];
+    status = ((__HAL_SPI_GET_FLAG(handle, SPI_FLAG_BSY) != RESET) ? 1 : 0);
     return status;
 }
 

--- a/source/spi_api.c
+++ b/source/spi_api.c
@@ -431,9 +431,7 @@ int spi_busy(spi_t *obj)
 /// @returns the number of bytes transferred, or `0` if nothing transferred
 static int spi_master_start_asynch_transfer(spi_t *obj, transfer_type_t transfer_type, void *tx, void *rx, size_t length)
 {
-#if DEBUG_STDIO
-    if (transfer_type != SPI_TRANSFER_TYPE_RX) DEBUG_PRINTF("SPI%u: Start: %u, %u\n", obj->spi.module+1, transfer_type, length);
-#endif
+    if (transfer_type != SPI_TRANSFER_TYPE_TX) DEBUG_PRINTF("SPI%u: Start: %u, %u\n", obj->spi.module+1, transfer_type, length);
     SPI_HandleTypeDef *handle = &SpiHandle[obj->spi.module];
     obj->spi.transfer_type = transfer_type;
 
@@ -456,8 +454,9 @@ static int spi_master_start_asynch_transfer(spi_t *obj, transfer_type_t transfer
             rc = HAL_SPI_TransmitReceive_IT(handle, (uint8_t*)tx, (uint8_t*)rx, words);
             break;
         case SPI_TRANSFER_TYPE_TX:
-            // we do not use `HAL_SPI_Transmit_IT`, since it has some unknown bug
+            // TODO: we do not use `HAL_SPI_Transmit_IT`, since it has some unknown bug
             // and makes the HAL keep some state and then that fails successive transfers
+            // rc = HAL_SPI_Transmit_IT(handle, (uint8_t*)tx, words);
             rc = HAL_SPI_TransmitReceive_IT(handle, (uint8_t*)tx, (uint8_t*)&sink, 1);
             length = is16bit ? 2 : 1;
             break;

--- a/source/spi_api.c
+++ b/source/spi_api.c
@@ -597,10 +597,16 @@ uint32_t spi_irq_handler_asynch(spi_t *obj)
 uint8_t spi_active(spi_t *obj)
 {
     SPI_HandleTypeDef *handle = &SpiHandle[obj->spi.module];
-    if (HAL_SPI_GetState(handle) == HAL_SPI_STATE_READY) {
-        return 0;
+    HAL_SPI_StateTypeDef state = HAL_SPI_GetState(handle);
+
+    switch(state) {
+        case HAL_SPI_STATE_RESET:
+        case HAL_SPI_STATE_READY:
+        case HAL_SPI_STATE_ERROR:
+            return 0;
+        default:
+            return -1;
     }
-    return -1;
 }
 
 void spi_abort_asynch(spi_t *obj)


### PR DESCRIPTION
Adds the functions as defined by the asynchronous interface in mbed-hal.
Successfully tested using the asynch-spi unittest in mbed-hal.

It uses interrupts for now (3 interrupts per transferred byte).

These changes rely on https://github.com/ARMmbed/mbed-hal-st-stm32f429zi/pull/13.

@bremoran @bogdanm @0xc0170