### PR TITLE
Choose target dependency only for legacy targets.

### DIFF
--- a/module.json
+++ b/module.json
@@ -27,13 +27,13 @@
     "mbed-hal": "*"
   },
   "targetDependencies": {
-    "stm32f401re": {
+    "stm32f401re-no-inherit": {
       "mbed-hal-st-stm32f401re": "~0.1.0"
     },
-    "stm32f429zi": {
+    "stm32f429zi-no-inherit": {
       "mbed-hal-st-stm32f429zi": "^1.0.0"
     },
-    "stm32f439zi": {
+    "stm32f439zi-no-inherit": {
       "mbed-hal-st-stm32f429zi": "^1.0.0"
     }
   }


### PR DESCRIPTION
With target inheritance, the target dependencies in this module will fall away.
However, since we cannot yet filter target dependencies on multiple properties, we need to add a specific `similarTo` tag to the legacy targets.

This change is dependent on:
- https://github.com/ARMmbed/target-st-nucleo-f401re-gcc/pull/8
- https://github.com/ARMmbed/target-st-stm32f429i-disco/pull/27

@autopulated Is this a breaking change? User upgrading only their stm32 targets will be fine, but when upgrading only their module, they will receive errors. Is there another way?

@bogdanm @0xc0170 @bremoran @mjs-arm 