### PR TITLE
Added __ADC2_CLK_ENABLE and __ADC3_CLK_ENABLE

### DIFF
--- a/mbed-hal-st-stm32f4/PeripheralPins.h
+++ b/mbed-hal-st-stm32f4/PeripheralPins.h
@@ -55,6 +55,8 @@ extern const PinMap PinMap_PWM[];
 
 extern const PinMap PinMap_UART_TX[];
 extern const PinMap PinMap_UART_RX[];
+extern const PinMap PinMap_UART_RTS[];
+extern const PinMap PinMap_UART_CTS[];
 
 //*** SPI ***
 

--- a/module.json
+++ b/module.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "uvisor-lib": ">=1.0.0,<3.0.0",
-    "mbed-hal-st-stm32cubef4": "^1.0.0",
+    "mbed-hal-st-stm32cubef4": "^1.3.0",
     "mbed-hal": "*"
   },
   "targetDependencies": {
@@ -31,7 +31,7 @@
       "mbed-hal-st-stm32f401re": "~0.4.0"
     },
     "stm32f429zi-no-inherit": {
-      "mbed-hal-st-stm32f429zi": "^1.1.0"
+      "mbed-hal-st-stm32f429zi": "^1.2.0"
     },
     "stm32f439zi-no-inherit": {
       "mbed-hal-st-stm32f429zi": "^1.0.0"

--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
   "name": "mbed-hal-st-stm32f4",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "mbed HAL module for STM32F4 microcontrollers",
   "keywords": [
     "mbed",
@@ -31,7 +31,7 @@
       "mbed-hal-st-stm32f401re": "~0.4.0"
     },
     "stm32f429zi-no-inherit": {
-      "mbed-hal-st-stm32f429zi": "^1.0.0"
+      "mbed-hal-st-stm32f429zi": "^1.1.0"
     },
     "stm32f439zi-no-inherit": {
       "mbed-hal-st-stm32f429zi": "^1.0.0"

--- a/source/i2c_api.c
+++ b/source/i2c_api.c
@@ -32,9 +32,6 @@
 
 #if DEVICE_I2C
 
-#ifndef USE_STM32F4XX_HAL_I2C__FIX
-#error Please use stm32f4xx_hal_i2c__FIX.c
-#endif
 
 #include "cmsis.h"
 #include "pinmap.h"

--- a/source/serial_api.c
+++ b/source/serial_api.c
@@ -1356,10 +1356,8 @@ void serial_tx_abort_asynch(serial_t *obj)
     // reset states
     handle->TxXferCount = 0;
     // update handle state
-    if(handle->State == HAL_UART_STATE_BUSY_TX_RX) {
-        handle->State = HAL_UART_STATE_BUSY_RX;
-    } else {
-        handle->State = HAL_UART_STATE_READY;
+    if(handle->gState == HAL_UART_STATE_BUSY_TX) {
+        handle->gState = HAL_UART_STATE_READY;
     }
 }
 
@@ -1377,10 +1375,8 @@ void serial_rx_abort_asynch(serial_t *obj)
     // reset states
     handle->RxXferCount = 0;
     // update handle state
-    if(handle->State == HAL_UART_STATE_BUSY_TX_RX) {
-        handle->State = HAL_UART_STATE_BUSY_TX;
-    } else {
-        handle->State = HAL_UART_STATE_READY;
+    if(handle->RxState == HAL_UART_STATE_BUSY_RX) {
+        handle->RxState = HAL_UART_STATE_READY;
     }
 }
 

--- a/source/serial_api.c
+++ b/source/serial_api.c
@@ -62,8 +62,8 @@
 #endif
 
 #define UART_NUM (8)
-#define UART_STATE_RX_ACTIVE 0x20
-#define UART_STATE_TX_ACTIVE 0x10
+#define UART_STATE_RX_ACTIVE 0x01
+#define UART_STATE_TX_ACTIVE 0x02
 
 #if DEVICE_SERIAL_ASYNCH_DMA
 
@@ -1250,7 +1250,7 @@ uint8_t serial_tx_active(serial_t *obj)
 {
     MBED_ASSERT(obj);
     UART_HandleTypeDef *handle = &UartHandle[SERIAL_OBJ(module)];
-    return ((HAL_UART_GetState(handle) & UART_STATE_TX_ACTIVE) ? 1 : 0);
+    return (((HAL_UART_GetState(handle)& ~(0x20)) & UART_STATE_RX_ACTIVE) ? 1 : 0);
 }
 
 /** Attempts to determine if the serial peripheral is already in use for RX
@@ -1262,7 +1262,7 @@ uint8_t serial_rx_active(serial_t *obj)
 {
     MBED_ASSERT(obj);
     UART_HandleTypeDef *handle = &UartHandle[SERIAL_OBJ(module)];
-    return ((HAL_UART_GetState(handle) & UART_STATE_RX_ACTIVE) ? 1 : 0);
+    return (((HAL_UART_GetState(handle)& ~(0x20)) & UART_STATE_RX_ACTIVE) ? 1 : 0);
 }
 
 /** The asynchronous TX and RX handler.


### PR DESCRIPTION
ADC2 and ADC3 clocks are needed for stm32f439 ADCs to work.
